### PR TITLE
Remove matrix configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,16 +10,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: [ '3.1.x', '6.0.x' ]
+#    strategy:
+#      matrix:
+#        dotnet-version: [ '3.1.x', '6.0.x' ]
 
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          # dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
 Turned out that running the matrix configuration caused it to flood the release api.
The release action should only run once, so if deploying multiple environments, it should collect the matrix jobs' artefacts first, then upload the full contents as the release